### PR TITLE
feat(VINScanner): update model year display

### DIFF
--- a/VINScanner/js/util.js
+++ b/VINScanner/js/util.js
@@ -9,7 +9,7 @@ export function extractVinDetails(result) {
   if (!result.exception) {
     parseResultInfo["Region"] = result.getFieldValue("region");
     parseResultInfo["Check Digit"] = result.getFieldValue("checkDigit");
-    parseResultInfo["Model Year"] = result.getFieldValue("modelYear");
+    parseResultInfo["Model Year"] = undefined?.split(",")?.join(" | ");
     parseResultInfo["Plant Code"] = result.getFieldValue("plantCode");
     parseResultInfo["VIS"] = result.getFieldValue("VIS");
   }

--- a/VINScanner/minimum-elements.html
+++ b/VINScanner/minimum-elements.html
@@ -177,7 +177,7 @@
         if (!result.exception) {
           parseResultInfo["Region"] = result.getFieldValue("region");
           parseResultInfo["Check Digit"] = result.getFieldValue("checkDigit");
-          parseResultInfo["Model Year"] = result.getFieldValue("modelYear");
+          parseResultInfo["Model Year"] = result.getFieldValue("modelYear")?.split(",")?.join(" | ");
           parseResultInfo["Plant Code"] = result.getFieldValue("plantCode");
           parseResultInfo["VIS"] = result.getFieldValue("VIS");
         }


### PR DESCRIPTION
Use " | " instead of comma to separate the model years if there are 2 or more values

![image](https://github.com/user-attachments/assets/f8eb727c-1b9a-4981-9f34-9fa03289e71c)
